### PR TITLE
Fix permission logging typo

### DIFF
--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -577,7 +577,7 @@ public class BluetoothSerial extends CordovaPlugin {
                 pluginResultMessage = "Fine location permission is granted.";
                 break;
             case CHECK_PERMISSIONS_REQ_CODE_ACCESS_COARSE_LOCATION:
-                logMessage = "User *rejected* coarse location permission";
+                logMessage = "User *granted* coarse location permission";
                 pluginResultMessage = "Coarse location permission is granted.";
                 break;
         }


### PR DESCRIPTION
## Summary
- correct coarse location permission log text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863b5f0728c8333ac80911b4cda8510